### PR TITLE
Fix test log utf-8 decoding error

### DIFF
--- a/mugen_riscv.py
+++ b/mugen_riscv.py
@@ -185,7 +185,7 @@ class TestTarget():
                     else:
                         os.system("sudo bash mugen.sh -f "+test_target+" -r "+testcase+" 2>&1 | tee -a exec.log")
                     for log in  os.listdir('logs/'+test_target+'/'+testcase):
-                        with open('logs/'+test_target+'/'+testcase+'/'+log , "r") as log_data:
+                        with open('logs/'+test_target+'/'+testcase+'/'+log, "r", encoding='utf-8', errors='ignore') as log_data:
                             log_found = re.search(r'See "systemctl status (.*)" and "journalctl -xe(.*)" for details.' , log_data.read())
                             if log_found is not None:
                                 os.system("sudo journalctl -xe --no-pager > logs/"+test_target+'/'+testcase+"/journelctl_for_"+log)


### PR DESCRIPTION
测试 ocaml-22.03 时出现如下异常， pr 来修复这个 utf-8 解码问题

```
Traceback (most recent call last):
  File "/root/mugen/mugen_riscv.py", line 270, in <module>
    test_res = test_target.Run(xpara=args.x,addDisk=args.addDisk,multiMachine=args.multiMachine,addNic=args.addNic)
  File "/root/mugen/mugen_riscv.py", line 189, in Run
    log_found = re.search(r'See "systemctl status (.*)" and "journalctl -xe(.*)" for details.' , log_data.read())
  File "/usr/lib64/python3.10/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x84 in position 2031: invalid start byte
```
