### PR TITLE
qemu_test.py add x86_64 support

### DIFF
--- a/qemu_test.py
+++ b/qemu_test.py
@@ -347,7 +347,8 @@ class QemuVM(object):
                   -cpu rv64,sv39=on "
         elif self.arch == 'x86_64':
             cmd = "qemu-system-x86_64 \
-                  -nographic -machine pc -accel kvm "
+                  -nographic -machine pc -accel kvm \
+                  -cpu qemu64,+rdrand "
         else:
             print('Unsupported qemu architecture ' + self.arch)
             return


### PR DESCRIPTION
+ 添加 x86 支持， ``qemuArch`` 参数指定 x86_64 架构，参考配置 [oE23030331_x86](https://github.com/weilinfox/PLCT-Working/blob/master/Note/oE23030331_x86)
+ 兼容旧的 RISC-V 配置， ``qemuArch`` 参数缺失默认使用 riscv64 架构
+ qemu RISC-V 指定 ``-cpu rv64,sv39=on`` ， qemu x86_64 指定 ``-cpu qemu64,+rdrand``
+ 启动 qemu 后检查命令行是否执行成功，若启动失败终端打印失败的命令行
+ 修复 https://github.com/brsf11/mugen-riscv/pull/13 没有引入 ``sys`` 包的 bug
+ 修复在没有指定 ``-kernel`` 情况下指定 ``-append`` 导致的 qemu 启动失败
+ 支持指定 ``-initrd``
