### PR TITLE
增加 --screen 参数开启 screen 作为 python subprocess 的可选替代管理 qemu 进程，另改为不配置额外网卡的 gateway

### DIFF
--- a/doc_riscv/Markdown/RISC-V-oE多线程QEMU自动化测试使用.md
+++ b/doc_riscv/Markdown/RISC-V-oE多线程QEMU自动化测试使用.md
@@ -41,6 +41,7 @@
                                 Specify the network bridge ip
           -t T                  Specify the number of generated free tap
           -F F                  Specify test config file
+          --screen              Use screen command to manage qemu processes
     ```
 
     例如
@@ -70,6 +71,7 @@
     - 使用多台实例进行测试时，各台实例之间需要通过网桥实现相互 ping 通， ``--addNic`` 和 ``"addNic"`` 项指定是否在创建 qemu 虚拟机时根据测试的需求以及每台实例的 IP 地址重新配置 qemu 实例的 mugen ``env.json`` 配置，和是否在调用 mugen_riscv.py 时传入 ``--addNic`` 参数，该参数依赖 ``--bridge_ip`` 和 ``-t`` 参数
     - 可使用 ``--bridge_ip`` 、 ``-t`` 参数或 ``"bridge ip"`` 、 ``"tap num"`` 项配置网桥 IP 和该连接在该网桥上的虚拟网卡数量，假设共有 50 个虚拟网卡，则虚拟网卡名称必须为 ``tap0`` ～ ``tap49``
     - 对于有 riscv 版本的测试套，测试套列表中可用原不带 riscv 后缀的测试套名称，脚本会自动优先匹配有后缀的版本，若想测试原测试套，可在运行 qemu_test.py 时加上 ``-m`` 参数或在配置文件中将 ``"mugenNative"`` 配置为 ``1``
+    - 由于测试中偶现 python subprocess 性能问题，可使用 ``--screen`` 参数或将 ``"useScreen"`` 配置项配置为 ``1``，使用 screen 命令作为替代方案管理 qemu 进程
 
 ### 使用例
 - 使用qemu_test.py测试不需要在宿主机上安装mugen依赖  
@@ -96,6 +98,7 @@
             "tap num":50,
             "mugenDir":"/root/mugen-riscv/",
             "listFile":"lists/previewV2part1remain3",
+            "useScreen":1,
             "generate":1
         }
     ```

--- a/qemu_test.py
+++ b/qemu_test.py
@@ -442,7 +442,7 @@ class QemuVM(object):
         print("config the machine "+str(self.id)+" nic name "+nic)
         print(ssh_exec(self , "nmcli c a type Ethernet con-name "+nic+" ifname "+nic , timeout=300)[1])
         print(ssh_exec(self , "nmcli c m "+nic+" ipv4.address "+self.tapip+"/24" , timeout=300)[1])
-        print(ssh_exec(self , "nmcli c m "+nic+" ipv4.gateway "+br_ip , timeout=300)[1])
+        # print(ssh_exec(self , "nmcli c m "+nic+" ipv4.gateway "+br_ip , timeout=300)[1])
         print(ssh_exec(self , "nmcli c m "+nic+" ipv4.method manual",timeout=300)[1])
         print(ssh_exec(self , "nmcli c up "+nic , timeout=300)[1])
         print(ssh_exec(self , "rm -rf "+self.path+"/conf",timeout=300)[1])

--- a/qemu_test.py
+++ b/qemu_test.py
@@ -478,7 +478,7 @@ class QemuVM(object):
 
     def waitPoweroff(self):
         if self.screen:
-            if os.system("screen -ls | grep "+self.name+" >/dev/null") == 0:
+            while os.system("screen -ls | grep "+self.name+" >/dev/null") == 0:
                 time.sleep(1)
         else:
             self.process.wait()

--- a/qemu_test.py
+++ b/qemu_test.py
@@ -482,8 +482,8 @@ class QemuVM(object):
                 time.sleep(1)
         else:
             self.process.wait()
-        while os.system('netstat -anp 2>&1 | grep '+str(self.port)+' > /dev/null') == 0:
-            time.sleep(1)
+            while os.system('netstat -anp 2>&1 | grep '+str(self.port)+' > /dev/null') == 0:
+                time.sleep(1)
 
     def destroy(self):
         ssh_exec(self,'poweroff')

--- a/qemu_test.py
+++ b/qemu_test.py
@@ -720,6 +720,8 @@ if __name__ == "__main__":
     if screen and os.system("screen -v >/dev/null") != 0:
         print("screen command not found")
         exit(-1)
+    else:
+        os.system('for i in $(screen -ls | grep mugenss | sed "s/.*\(mugenss[0-9]*\).*/\\1/"); do screen -X -S $i quit; done')
 
     if preImg == True or genList == True:
         if preImg == True and (bkFile not in os.listdir(workingDir)):
@@ -802,7 +804,7 @@ if __name__ == "__main__":
         for i in range(threadNum):
             dispathcers.append(Dispatcher(qemuVM=qemuVM[i] , targetQueue=targetQueue , tapQueue=tap , br_ip=bridge_ip , step = threadNum))
             dispathcers[i].start()
-            time.sleep(0.5)
+            time.sleep(2)
 
         isAlive = True
         isEnd = False

--- a/qemu_test.py
+++ b/qemu_test.py
@@ -99,7 +99,7 @@ class Dispatcher(Thread):
                                                             user=self.qemuVM.user , password=self.qemuVM.password,
                                                             arch=self.qemuVM.arch, initrd=self.qemuVM.initrd,
                                                             kernel=self.qemuVM.kernel, kparms=self.qemuVM.kparms, bios=self.qemuVM.bios, pflash=self.qemuVM.pflash,
-                                                            workingDir=self.qemuVM.workingDir , bkfile=self.qemuVM.bkFile , path=self.qemuVM.path,
+                                                            workingDir=self.qemuVM.workingDir , bkfile=self.qemuVM.bkFile , path=self.qemuVM.path, screen=self.qemuVM.screen,
                                                             ))
                                 self.attachVM[i-1].start(disk=self.initTarget[1],machine=self.initTarget[2],tap_number=self.initTarget[3]+1,taplist=[self.tapQueue.get() for i in range(self.initTarget[3]+1)])
                                 self.attachVM[i-1].waitReady()
@@ -135,7 +135,7 @@ class Dispatcher(Thread):
                                                             user=self.qemuVM.user , password=self.qemuVM.password,
                                                             arch=self.qemuVM.arch, initrd=self.qemuVM.initrd,
                                                             kernel=self.qemuVM.kernel, kparms=self.qemuVM.kparms, bios=self.qemuVM.bios, pflash=self.qemuVM.pflash,
-                                                            workingDir=self.qemuVM.workingDir , bkfile=self.qemuVM.bkFile , path=self.qemuVM.path,
+                                                            workingDir=self.qemuVM.workingDir , bkfile=self.qemuVM.bkFile , path=self.qemuVM.path, screen=self.qemuVM.screen,
                                                             ))
                                 self.attachVM[i-1].start(disk=self.initTarget[1],machine=self.initTarget[2],tap_number=1,taplist=[self.tapQueue.get()])
                                 self.attachVM[i-1].waitReady()
@@ -206,7 +206,7 @@ class Dispatcher(Thread):
                                                                 user=self.qemuVM.user , password=self.qemuVM.password,
                                                                 arch=self.qemuVM.arch, initrd=self.qemuVM.initrd,
                                                                 kernel=self.qemuVM.kernel, kparms=self.qemuVM.kparms, bios=self.qemuVM.bios, pflash=self.qemuVM.pflash,
-                                                                workingDir=self.qemuVM.workingDir , bkfile=self.qemuVM.bkFile , path=self.qemuVM.path,
+                                                                workingDir=self.qemuVM.workingDir , bkfile=self.qemuVM.bkFile , path=self.qemuVM.path, screen=self.qemuVM.screen,
                                                                 ))
                                     self.attachVM[i-1].start(disk=target[1],machine=target[2],tap_number=target[3]+1,taplist=[self.tapQueue.get() for i in range(target[3]+1)])
                                     self.attachVM[i-1].waitReady()
@@ -239,7 +239,7 @@ class Dispatcher(Thread):
                                                                 user=self.qemuVM.user , password=self.qemuVM.password,
                                                                 arch=self.qemuVM.arch, initrd=self.qemuVM.initrd,
                                                                 kernel=self.qemuVM.kernel, kparms=self.qemuVM.kparms, bios=self.qemuVM.bios, pflash=self.qemuVM.pflash,
-                                                                workingDir=self.qemuVM.workingDir , bkfile=self.qemuVM.bkFile , path=self.qemuVM.path,
+                                                                workingDir=self.qemuVM.workingDir , bkfile=self.qemuVM.bkFile , path=self.qemuVM.path, screen=self.qemuVM.screen,
                                                                 ))
                                     self.attachVM[i-1].start(disk=target[1],machine=target[2],tap_number=1,taplist=[self.tapQueue.get()])
                                     self.attachVM[i-1].waitReady()
@@ -289,7 +289,7 @@ class Dispatcher(Thread):
 
 
 class QemuVM(object):
-    def __init__(self, arch, vcpu, memory, workingDir, bkfile, kernel, kparms, initrd, bios, pflash, id=1, port=12055, user='root',password='openEuler12#$',
+    def __init__(self, arch, vcpu, memory, workingDir, bkfile, kernel, kparms, initrd, bios, pflash, screen, id=1, port=12055, user='root',password='openEuler12#$',
                   path='/root/GitRepo/mugen-riscv' , restore=True, runArgs=''):
         self.arch = arch
         self.id = id
@@ -303,24 +303,26 @@ class QemuVM(object):
         self.runArgs = runArgs
         self.mac = id+1
         self.tapls = []
+        self.screen = screen
+        self.name = "mugenss"+str(self.id)
         if self.workingDir[-1] != '/':
             self.workingDir += '/'
 
     def start(self , disk=1 , machine=1 , tap_number=0 , taplist=[]):
         self.tapls = taplist
-        self.port = findAvalPort(1)[0]
         if self.drive in os.listdir(self.workingDir):
             os.system('rm -f '+self.workingDir+self.drive)
         if self.restore:
-            cmd = 'qemu-img create -f qcow2 -F qcow2 -b '+self.workingDir+self.bkFile+' '+self.workingDir+self.drive
+            cmd = 'qemu-img create -f qcow2 -F qcow2 -b '+self.workingDir+self.bkFile+' '+self.workingDir+self.drive+" >/dev/null"
             res = os.system(cmd)
             if res != 0:
                 print('Failed to create cow img: '+self.drive)
                 return -1
         os.system('rm -f '+self.workingDir+'disk'+str(self.id)+'-*')
         if disk > 1:
+            print('Append '+str(disk-1)+" disks")
             for i in range(1 , disk):
-                cmd = 'qemu-img create -f qcow2 '+self.workingDir+"disk"+str(self.id)+'-'+str(i)+'.qcow2 500M'
+                cmd = 'qemu-img create -f qcow2 '+self.workingDir+"disk"+str(self.id)+'-'+str(i)+'.qcow2 500M >/dev/null'
                 res = os.system(cmd)
                 if res != 0:
                     print('Failed to create img: disk'+str(id)+'-'+str(i))
@@ -356,7 +358,6 @@ class QemuVM(object):
             cmd = "cp "+self.pflash+" "+self.npflash
             os.system(cmd)
 
-        ssh_port=self.port
         if self.arch == 'riscv64':
             cmd = "qemu-system-riscv64 \
                   -nographic -machine virt \
@@ -401,15 +402,26 @@ class QemuVM(object):
                 cmd += "-netdev tap,id=net" + used_tap + ",ifname=" + used_tap + ",script=no,downscript=no -device virtio-net-pci,netdev=net" + used_tap + ",mac=52:54:00:11:45:{:0>2d}".format(self.mac) + " "
                 self.mac += 1
 
-        cmd += "-netdev user,id=usernet,hostfwd=tcp::" + str(ssh_port) + "-:22 -device virtio-net-pci,netdev=usernet,mac=52:54:00:11:45:{:0>2d}".format(self.mac)
-        self.process = subprocess.Popen(args=cmd,stderr=subprocess.PIPE,stdout=subprocess.PIPE,stdin=subprocess.PIPE,encoding='utf-8',shell=True)
-        time.sleep(1)
-        ret = self.process.poll()
-        if ret is not None:
-            print("Qemu process terminate unexpectedly " + str(ret))
-            print(self.process.communicate())
+        self.port = findAvalPort(1)[0]
+        cmd += "-netdev user,id=usernet,hostfwd=tcp::" + str(self.port) + "-:22 -device virtio-net-pci,netdev=usernet,mac=52:54:00:11:45:{:0>2d}".format(self.mac)
+        if self.screen:
+            if os.system("screen -ls | grep "+self.name+" >/dev/null") == 0:
+                os.system("screen -X -S "+self.name+" quit")
+            os.system("screen -S "+self.name+" -d -m "+cmd)
+            time.sleep(1)
+            if os.system("screen -ls | grep "+self.name+" >/dev/null") != 0:
+                print("Qemu process terminate unexpectedly " + cmd)
+            else:
+                print("Qemu process is running with cmdline " + cmd)
         else:
-            print("Qemu process is running with cmdline " + cmd)
+            self.process = subprocess.Popen(args=cmd,stderr=subprocess.PIPE,stdout=subprocess.PIPE,stdin=subprocess.PIPE,encoding='utf-8',shell=True)
+            time.sleep(1)
+            ret = self.process.poll()
+            if ret is not None:
+                print("Qemu process terminate unexpectedly " + str(ret))
+                print(self.process.communicate())
+            else:
+                print("Qemu process is running with cmdline " + cmd)
 
     def waitReady(self):
         conn = 519
@@ -465,7 +477,11 @@ class QemuVM(object):
         return False
 
     def waitPoweroff(self):
-        self.process.wait()
+        if self.screen:
+            if os.system("screen -ls | grep "+self.name+" >/dev/null") == 0:
+                time.sleep(1)
+        else:
+            self.process.wait()
         while os.system('netstat -anp 2>&1 | grep '+str(self.port)+' > /dev/null') == 0:
             time.sleep(1)
 
@@ -505,6 +521,7 @@ if __name__ == "__main__":
     parser.add_argument('--bridge_ip', type=str, help='Specify the network bridge ip')
     parser.add_argument('-t', type=int, default=0, help='Specify the number of generated free tap')
     parser.add_argument('-F',type=str,help='Specify test config file')
+    parser.add_argument('--screen',action='store_true',default=False,help='Use screen command to manage qemu processes')
     args = parser.parse_args()
 
     test_env = TestEnv()
@@ -524,6 +541,7 @@ if __name__ == "__main__":
     user , password = "root","openEuler12#$"
     addDisk, multiMachine, addNic = False,False,False
     bridge_ip = None
+    screen = False
     tap = Queue()
     
 
@@ -579,6 +597,8 @@ if __name__ == "__main__":
         if configData.__contains__('tap num'):
             for i in range(configData['tap num']):
                 tap.put('tap'+str(i))
+        if configData.__contains__('useScreen') and configData['useScreen'] == 1:
+            screen = True
         if configData.__contains__('qemuArch') and type(configData['qemuArch']) == str:
             arch = configData['qemuArch']
             if arch not in ['riscv64', 'x86_64']:
@@ -663,6 +683,8 @@ if __name__ == "__main__":
         if args.t > 0:
             for i in range(args.t):
                 tap.put('tap'+str(i))
+        if args.screen:
+            screen = True
 
         if args.w != None and (args.B != None or args.K != None or args.U != None) and args.D != None:
             workingDir = args.w
@@ -695,6 +717,10 @@ if __name__ == "__main__":
             print('Please specify working directory and bios or kernel and drive file!')
             exit(-1)
 
+    if screen and os.system("screen -v >/dev/null") != 0:
+        print("screen command not found")
+        exit(-1)
+
     if preImg == True or genList == True:
         if preImg == True and (bkFile not in os.listdir(workingDir)):
             res = os.system('qemu-img create -f qcow2 -F qcow2 -b '+workingDir+orgDrive+' '+workingDir+bkFile)
@@ -703,7 +729,7 @@ if __name__ == "__main__":
                 exit(-1)
 
         preVM = QemuVM(id=1, port=findAvalPort(1)[0], user=user, password=password, arch=arch, kernel=kernel, kparms=kparms, initrd=initrd, bios=bios, pflash=pflash,
-                       vcpu=coreNum, memory=memSize, path=mugenPath, workingDir=workingDir, bkfile=bkFile,
+                       vcpu=coreNum, memory=memSize, path=mugenPath, workingDir=workingDir, bkfile=bkFile, screen=screen,
                        restore=False)
         preVM.start()
         preVM.waitReady()
@@ -764,7 +790,7 @@ if __name__ == "__main__":
             qemuVM.append(QemuVM(id=i , vcpu=coreNum , memory=memSize,
                                  user=user , password=password,
                                  arch=arch, initrd=initrd, kernel=kernel, kparms=kparms, bios=bios, pflash=pflash,
-                                 workingDir=workingDir , bkfile=bkFile , path=mugenPath,
+                                 workingDir=workingDir , bkfile=bkFile , path=mugenPath, screen=screen,
                                  runArgs=runningArg))   
         targetQueue = Queue()
         for target in test_target.test_list:


### PR DESCRIPTION
在使用 python subprocess 管理 qemu 进程时，偶现虚拟机启动一半假死的情况，此时杀死 python 进程则虚拟机进程可以继续动作直至启动完成

为了确保测试发现问题时可以具有一个临时替代方案，添加 ``--screen`` 参数或在配置文件添加 ``"useScreen": 1`` 开启使用 screen 管理虚拟机进程，在必要的时候亦方便在测试过程中对测试机进行手动干预

另外适当提高了建立两个虚拟机之间的延时，有利于减少转发端口冲突情况的发生
